### PR TITLE
Prep for 0.19: remove `toString` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ import Json.Decode.Pipeline exposing (..)
 import Json.Encode
 import Http
 import String
+import String.Conversions as String
 
 
 type alias Book =

--- a/examples/books/elm-package.json
+++ b/examples/books/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "NoRedInk/string-conversions": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0"

--- a/examples/books/elm/Generated/BooksApi.elm
+++ b/examples/books/elm/Generated/BooksApi.elm
@@ -86,7 +86,7 @@ getBooksByBookId capture_bookId =
             String.join "/"
                 [ "http://localhost:8000"
                 , "books"
-                , capture_bookId |> String.fromInt |> Http.encodeUri
+                , capture_bookId |> toString |> Http.encodeUri
                 ]
         , body =
             Http.emptyBody

--- a/examples/books/elm/Generated/BooksApi.elm
+++ b/examples/books/elm/Generated/BooksApi.elm
@@ -5,6 +5,7 @@ import Json.Decode.Pipeline exposing (..)
 import Json.Encode
 import Http
 import String
+import String.Conversions as String
 
 
 type alias Book =
@@ -22,7 +23,7 @@ encodeBook x =
         [ ( "name", Json.Encode.string x.name )
         ]
 
-postBooks : Book -> Http.Request (Book)
+postBooks : Book -> Http.Request (Http.Response (Book))
 postBooks body =
     Http.request
         { method =
@@ -37,14 +38,18 @@ postBooks body =
         , body =
             Http.jsonBody (encodeBook body)
         , expect =
-            Http.expectJson decodeBook
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString decodeBook response.body))
         , timeout =
             Nothing
         , withCredentials =
             False
         }
 
-getBooks : Http.Request (List (Book))
+getBooks : Http.Request (Http.Response (List (Book)))
 getBooks =
     Http.request
         { method =
@@ -59,14 +64,18 @@ getBooks =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson (list decodeBook)
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString (list decodeBook) response.body))
         , timeout =
             Nothing
         , withCredentials =
             False
         }
 
-getBooksByBookId : Int -> Http.Request (Book)
+getBooksByBookId : Int -> Http.Request (Http.Response (Book))
 getBooksByBookId capture_bookId =
     Http.request
         { method =
@@ -77,12 +86,16 @@ getBooksByBookId capture_bookId =
             String.join "/"
                 [ "http://localhost:8000"
                 , "books"
-                , capture_bookId |> toString |> Http.encodeUri
+                , capture_bookId |> String.fromInt |> Http.encodeUri
                 ]
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson decodeBook
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString decodeBook response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/examples/books/generate.hs
+++ b/examples/books/generate.hs
@@ -17,9 +17,8 @@ data Book = Book
 
 instance ElmType Book
 
-type BooksApi = "books" :> ReqBody '[JSON] Book :> Post '[JSON] Book
-           :<|> "books" :> Get '[JSON] [Book]
-           :<|> "books" :> Capture "bookId" Int :> Get '[JSON] Book
+type BooksApi
+   = "books" :> ReqBody '[ JSON] Book :> Post '[ JSON] Book :<|> "books" :> Get '[ JSON] [Book] :<|> "books" :> Capture "bookId" Int :> Get '[ JSON] Book
 
 myElmOpts :: ElmOptions
 myElmOpts = defElmOptions { urlPrefix = Static "http://localhost:8000" }

--- a/examples/e2e-tests/elm-package.json
+++ b/examples/e2e-tests/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "NoRedInk/string-conversions": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0"

--- a/examples/e2e-tests/elm/Generated/Api.elm
+++ b/examples/e2e-tests/elm/Generated/Api.elm
@@ -1,27 +1,32 @@
 module Generated.Api exposing (..)
 
+import Http
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
 import Json.Encode
-import Http
 import String
+import String.Conversions as String
 
 
 type alias Response =
     { origin : String
     }
 
+
 decodeResponse : Decoder Response
 decodeResponse =
     decode Response
         |> required "origin" string
 
+
 type NoContent
     = NoContent
+
 
 type alias MessageBody =
     { message : String
     }
+
 
 encodeMessageBody : MessageBody -> Json.Encode.Value
 encodeMessageBody x =
@@ -29,39 +34,47 @@ encodeMessageBody x =
         [ ( "message", Json.Encode.string x.message )
         ]
 
+
 decodeMessageBody : Decoder MessageBody
 decodeMessageBody =
     decode MessageBody
         |> required "message" string
 
+
 type alias ResponseWithJson =
     { json : MessageBody
     }
+
 
 decodeResponseWithJson : Decoder ResponseWithJson
 decodeResponseWithJson =
     decode ResponseWithJson
         |> required "json" decodeMessageBody
 
+
 type alias QueryArgs =
     { q : String
     }
+
 
 decodeQueryArgs : Decoder QueryArgs
 decodeQueryArgs =
     decode QueryArgs
         |> required "q" string
 
+
 type alias ResponseWithArgs =
     { args : QueryArgs
     }
+
 
 decodeResponseWithArgs : Decoder ResponseWithArgs
 decodeResponseWithArgs =
     decode ResponseWithArgs
         |> required "args" decodeQueryArgs
 
-getIp : Http.Request (Response)
+
+getIp : Http.Request Response
 getIp =
     Http.request
         { method =
@@ -83,7 +96,8 @@ getIp =
             False
         }
 
-getStatus204 : Http.Request (NoContent)
+
+getStatus204 : Http.Request NoContent
 getStatus204 =
     Http.request
         { method =
@@ -112,7 +126,8 @@ getStatus204 =
             False
         }
 
-postPost : MessageBody -> Http.Request (ResponseWithJson)
+
+postPost : MessageBody -> Http.Request ResponseWithJson
 postPost body =
     Http.request
         { method =
@@ -134,41 +149,44 @@ postPost body =
             False
         }
 
-getGet : Maybe (String) -> Http.Request (ResponseWithArgs)
+
+getGet : Maybe String -> Http.Request ResponseWithArgs
 getGet query_q =
     let
         params =
             List.filter (not << String.isEmpty)
                 [ query_q
-                    |> Maybe.map (Http.encodeUri >> (++) "q=")
+                    |> Maybe.map (identity >> Http.encodeUri >> (++) "q=")
                     |> Maybe.withDefault ""
                 ]
     in
-        Http.request
-            { method =
-                "GET"
-            , headers =
-                []
-            , url =
-                String.join "/"
-                    [ "https://httpbin.org"
-                    , "get"
-                    ]
-                ++ if List.isEmpty params then
-                       ""
-                   else
-                       "?" ++ String.join "&" params
-            , body =
-                Http.emptyBody
-            , expect =
-                Http.expectJson decodeResponseWithArgs
-            , timeout =
-                Nothing
-            , withCredentials =
-                False
-            }
+    Http.request
+        { method =
+            "GET"
+        , headers =
+            []
+        , url =
+            String.join "/"
+                [ "https://httpbin.org"
+                , "get"
+                ]
+                ++ (if List.isEmpty params then
+                        ""
+                    else
+                        "?" ++ String.join "&" params
+                   )
+        , body =
+            Http.emptyBody
+        , expect =
+            Http.expectJson decodeResponseWithArgs
+        , timeout =
+            Nothing
+        , withCredentials =
+            False
+        }
 
-getByPath : String -> Http.Request (Response)
+
+getByPath : String -> Http.Request Response
 getByPath capture_path =
     Http.request
         { method =

--- a/examples/giphy/elm-package.json
+++ b/examples/giphy/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "NoRedInk/string-conversions": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0"

--- a/examples/readme-example/elm-package.json
+++ b/examples/readme-example/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "NoRedInk/string-conversions": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0"

--- a/servant-elm.cabal
+++ b/servant-elm.cabal
@@ -32,7 +32,7 @@ library
                      , Servant.Elm.Internal.Generate
                      , Servant.Elm.Internal.Orphans
   build-depends:       base >= 4.7 && < 5
-                     , elm-export      >= 0.5
+                     , elm-export
                      , lens
                      , servant         >= 0.8
                      , servant-foreign >= 0.8

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -483,8 +483,8 @@ toStringSrcTypes _ _ (ElmPrimitive (EList (ElmPrimitive EChar))) = "identity"
 toStringSrcTypes operator opts (ElmPrimitive (EList argType)) = toStringSrcTypes operator opts argType
 toStringSrcTypes _ opts argType
     | isElmStringType opts argType   = "identity"
-    | isElmIntType opts argType   = "String.fromInt"
-    | isElmFloatType opts argType = "String.fromFloat"
+    | isElmIntType opts argType   = "toString" -- in elm 0.19 "String.fromInt"
+    | isElmFloatType opts argType = "toString" -- in elm 0.19 "String.fromFloat"
     | isElmBoolType opts argType  = "String.fromBool" -- We should change this to return `true`/`false` but this mimics the old behavior.
     | isElmCharType opts argType  = "String.fromChar"
     | otherwise                   = error ("Sorry, we don't support other types than `String`, `Int` and `Float` atm. " <> show argType)

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -375,7 +375,7 @@ mkRequest opts request =
 
     headers =
         [ "Http.header" <+> dquotes headerName <+>
-            parens (toStringSrc ">>" opts (header ^. F.headerArg . F.argType) <> headerArgName)
+            parens (toStringSrc "" opts (header ^. F.headerArg . F.argType) <> headerArgName)
         | header <- request ^. F.reqHeaders
         , headerName <- [header ^. F.headerArg . F.argName . to (stext . F.unPathSegment)]
         , headerArgName <- [elmHeaderArg header]

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -476,7 +476,7 @@ toStringSrc operator opts argType
 
 
 toStringSrcTypes :: T.Text -> ElmOptions -> ElmDatatype -> T.Text
-toStringSrcTypes operator opts (ElmPrimitive (EMaybe argType)) = toStringSrcTypes operator opts argType
+toStringSrcTypes operator opts (ElmPrimitive (EMaybe argType)) = "Maybe.map (" <> toStringSrcTypes operator opts argType <> ") |> Maybe.withDefault \"\""
  -- [Char] == String so we can just use identity here.
  -- We can't return `""` here, because this string might be nested in a `Maybe` or `List`.
 toStringSrcTypes _ _ (ElmPrimitive (EList (ElmPrimitive EChar))) = "identity"

--- a/src/Servant/Elm/Internal/Orphans.hs
+++ b/src/Servant/Elm/Internal/Orphans.hs
@@ -12,3 +12,8 @@ instance ElmType ElmDatatype where
 
 
 instance ElmType NoContent
+
+-- TODO: Generate Elm functions that can handle the response headers. PRs
+-- welcome!
+instance (ElmType a) => ElmType (Headers ls a) where
+  toElmType = toElmType . getResponse

--- a/src/Servant/Elm/Internal/Orphans.hs
+++ b/src/Servant/Elm/Internal/Orphans.hs
@@ -12,8 +12,3 @@ instance ElmType ElmDatatype where
 
 
 instance ElmType NoContent
-
--- TODO: Generate Elm functions that can handle the response headers. PRs
--- welcome!
-instance (ElmType a) => ElmType (Headers ls a) where
-  toElmType = toElmType . getResponse

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,8 +8,10 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-- elm-export-0.6.0.1
+- location:
+    git: git@github.com:NoRedInk/elm-export
+    commit: a4307e6f641e057f247584115e1a0436d72ad924
+  extra-dep: true
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/CompileSpec.hs
+++ b/test/CompileSpec.hs
@@ -75,7 +75,8 @@ createCache = do
               "elm-lang/core": "5.0.0 <= v < 6.0.0",
               "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
               "elm-lang/http": "1.0.0 <= v < 2.0.0",
-              "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0"
+              "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+              "NoRedInk/string-conversions": "1.0.0 <= v < 2.0.0"
           },
           "elm-version": "0.18.0 <= v < 0.19.0"
       }

--- a/test/GenerateSpec.hs
+++ b/test/GenerateSpec.hs
@@ -35,38 +35,48 @@ spec = do
                           [ ( "test/elm-sources/getOneSource.elm"
                             , "module GetOneSource exposing (..)\n\n" <>
                               "import Http\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Json.Decode exposing (..)\n\n\n")
                           , ( "test/elm-sources/postTwoSource.elm"
                             , "module PostTwoSource exposing (..)\n\n" <>
                               "import Http\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Json.Decode exposing (..)\n" <>
                               "import Json.Encode\n\n\n")
                           , ( "test/elm-sources/getBooksByIdSource.elm"
                             , "module GetBooksByIdSource exposing (..)\n\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Http\n\n\n")
                           , ( "test/elm-sources/getBooksByTitleSource.elm"
                             , "module GetBooksByTitleSource exposing (..)\n\n" <>
-                              "import Http\n\n\n")
+                              "import Http\n" <>
+                              "import String.Conversions as String\n\n\n")
                           , ( "test/elm-sources/getBooksSource.elm"
                             , "module GetBooksSource exposing (..)\n\n" <>
                               "import Http\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Json.Decode exposing (..)\n\n\n")
                           , ( "test/elm-sources/postBooksSource.elm"
                             , "module PostBooksSource exposing (..)\n\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Http\n\n\n")
                           , ( "test/elm-sources/getNothingSource.elm"
                             , "module GetNothingSource exposing (..)\n\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Http\n\n\n")
                           , ( "test/elm-sources/putNothingSource.elm"
                             , "module PutNothingSource exposing (..)\n\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Http\n\n\n")
                           , ( "test/elm-sources/getWithaheaderSource.elm"
                             , "module GetWithAHeaderSource exposing (..)\n\n" <>
                               "import Http\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Json.Decode exposing (..)\n\n\n")
                           , ( "test/elm-sources/getWitharesponseheaderSource.elm"
                             , "module GetWithAResponseHeaderSource exposing (..)\n\n" <>
                               "import Http\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Json.Decode exposing (..)\n\n\n")]
                   let generated = map (<> "\n") (generateElmForAPI testApi)
                   generated `itemsShouldBe` expected
@@ -79,6 +89,7 @@ spec = do
                           [ ( "test/elm-sources/getOneWithDynamicUrlSource.elm"
                             , "module GetOneWithDynamicUrlSource exposing (..)\n\n" <>
                               "import Http\n" <>
+                              "import String.Conversions as String\n" <>
                               "import Json.Decode exposing (..)\n\n\n")]
                   let generated =
                           map

--- a/test/elm-sources/elm-package.json
+++ b/test/elm-sources/elm-package.json
@@ -10,7 +10,8 @@
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "elm-lang/http": "1.0.0 <= v < 2.0.0"
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "NoRedInk/string-conversions": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/test/elm-sources/getBooksByIdSource.elm
+++ b/test/elm-sources/getBooksByIdSource.elm
@@ -14,7 +14,7 @@ getBooksById capture_id =
             String.join "/"
                 [ ""
                 , "books"
-                , capture_id |> toString |> Http.encodeUri
+                , capture_id |> String.fromInt |> Http.encodeUri
                 ]
         , body =
             Http.emptyBody

--- a/test/elm-sources/getBooksByIdSource.elm
+++ b/test/elm-sources/getBooksByIdSource.elm
@@ -1,9 +1,10 @@
 module GetBooksByIdSource exposing (..)
 
+import String.Conversions as String
 import Http
 
 
-getBooksById : Int -> Http.Request (Book)
+getBooksById : Int -> Http.Request (Http.Response (Book))
 getBooksById capture_id =
     Http.request
         { method =
@@ -14,12 +15,16 @@ getBooksById capture_id =
             String.join "/"
                 [ ""
                 , "books"
-                , capture_id |> String.fromInt |> Http.encodeUri
+                , capture_id |> toString |> Http.encodeUri
                 ]
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson decodeBook
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString decodeBook response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getBooksByTitleSource.elm
+++ b/test/elm-sources/getBooksByTitleSource.elm
@@ -1,9 +1,10 @@
 module GetBooksByTitleSource exposing (..)
 
 import Http
+import String.Conversions as String
 
 
-getBooksByTitle : String -> Http.Request (Book)
+getBooksByTitle : String -> Http.Request (Http.Response (Book))
 getBooksByTitle capture_title =
     Http.request
         { method =
@@ -19,7 +20,11 @@ getBooksByTitle capture_title =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson decodeBook
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString decodeBook response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -4,7 +4,7 @@ import Http
 import Json.Decode exposing (..)
 
 
-getBooks : Bool -> Maybe (String) -> Maybe (Int) -> List (Maybe (Bool)) -> Http.Request (List (Book))
+getBooks : Bool -> Maybe String -> Maybe Int -> List (Maybe Bool) -> Http.Request (List Book)
 getBooks query_published query_sort query_year query_filters =
     let
         params =
@@ -14,36 +14,37 @@ getBooks query_published query_sort query_year query_filters =
                   else
                     ""
                 , query_sort
-                    |> Maybe.map (Http.encodeUri >> (++) "sort=")
+                    |> Maybe.map (identity >> Http.encodeUri >> (++) "sort=")
                     |> Maybe.withDefault ""
                 , query_year
-                    |> Maybe.map (toString >> Http.encodeUri >> (++) "year=")
+                    |> Maybe.map (String.fromInt >> Http.encodeUri >> (++) "year=")
                     |> Maybe.withDefault ""
                 , query_filters
-                    |> List.map (\val -> "query_filters[]=" ++ (val |> toString |> Http.encodeUri))
+                    |> List.map (\val -> "query_filters[]=" ++ (val |> String.fromBool |> Http.encodeUri))
                     |> String.join "&"
                 ]
     in
-        Http.request
-            { method =
-                "GET"
-            , headers =
-                []
-            , url =
-                String.join "/"
-                    [ ""
-                    , "books"
-                    ]
-                ++ if List.isEmpty params then
-                       ""
-                   else
-                       "?" ++ String.join "&" params
-            , body =
-                Http.emptyBody
-            , expect =
-                Http.expectJson (list decodeBook)
-            , timeout =
-                Nothing
-            , withCredentials =
-                False
-            }
+    Http.request
+        { method =
+            "GET"
+        , headers =
+            []
+        , url =
+            String.join "/"
+                [ ""
+                , "books"
+                ]
+                ++ (if List.isEmpty params then
+                        ""
+                    else
+                        "?" ++ String.join "&" params
+                   )
+        , body =
+            Http.emptyBody
+        , expect =
+            Http.expectJson (list decodeBook)
+        , timeout =
+            Nothing
+        , withCredentials =
+            False
+        }

--- a/test/elm-sources/getNothingSource.elm
+++ b/test/elm-sources/getNothingSource.elm
@@ -1,9 +1,10 @@
 module GetNothingSource exposing (..)
 
+import String.Conversions as String
 import Http
 
 
-getNothing : Http.Request (NoContent)
+getNothing : Http.Request (Http.Response (NoContent))
 getNothing =
     Http.request
         { method =
@@ -19,9 +20,9 @@ getNothing =
             Http.emptyBody
         , expect =
             Http.expectStringResponse
-                (\{ body } ->
-                    if String.isEmpty body then
-                        Ok NoContent
+                (\response ->
+                    if String.isEmpty response.body then
+                        Ok { response | body = NoContent }
                     else
                         Err "Expected the response body to be empty"
                 )

--- a/test/elm-sources/getOneSource.elm
+++ b/test/elm-sources/getOneSource.elm
@@ -1,10 +1,11 @@
 module GetOneSource exposing (..)
 
 import Http
+import String.Conversions as String
 import Json.Decode exposing (..)
 
 
-getOne : Http.Request (Int)
+getOne : Http.Request (Http.Response (Int))
 getOne =
     Http.request
         { method =
@@ -19,7 +20,11 @@ getOne =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson int
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString int response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getOneWithDynamicUrlSource.elm
+++ b/test/elm-sources/getOneWithDynamicUrlSource.elm
@@ -1,10 +1,11 @@
 module GetOneWithDynamicUrlSource exposing (..)
 
 import Http
+import String.Conversions as String
 import Json.Decode exposing (..)
 
 
-getOne : String -> Http.Request (Int)
+getOne : String -> Http.Request (Http.Response (Int))
 getOne urlBase =
     Http.request
         { method =
@@ -19,7 +20,11 @@ getOne urlBase =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson int
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString int response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -1,17 +1,18 @@
 module GetWithAHeaderSource exposing (..)
 
 import Http
+import String.Conversions as String
 import Json.Decode exposing (..)
 
 
-getWithaheader : String -> Int -> Http.Request String
+getWithaheader : String -> Int -> Http.Request (Http.Response (String))
 getWithaheader header_myStringHeader header_MyIntHeader =
     Http.request
         { method =
             "GET"
         , headers =
-            [ Http.header "myStringHeader" header_myStringHeader
-            , Http.header "MyIntHeader" (String.fromInt header_MyIntHeader)
+            [ Http.header "myStringHeader" (header_myStringHeader)
+            , Http.header "MyIntHeader" (toString header_MyIntHeader)
             ]
         , url =
             String.join "/"
@@ -21,7 +22,11 @@ getWithaheader header_myStringHeader header_MyIntHeader =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson string
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString string response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -4,14 +4,14 @@ import Http
 import Json.Decode exposing (..)
 
 
-getWithaheader : String -> Int -> Http.Request (String)
+getWithaheader : String -> Int -> Http.Request String
 getWithaheader header_myStringHeader header_MyIntHeader =
     Http.request
         { method =
             "GET"
         , headers =
             [ Http.header "myStringHeader" header_myStringHeader
-            , Http.header "MyIntHeader" (toString header_MyIntHeader)
+            , Http.header "MyIntHeader" (String.fromInt header_MyIntHeader)
             ]
         , url =
             String.join "/"

--- a/test/elm-sources/getWitharesponseheaderSource.elm
+++ b/test/elm-sources/getWitharesponseheaderSource.elm
@@ -1,10 +1,11 @@
 module GetWithAResponseHeaderSource exposing (..)
 
 import Http
+import String.Conversions as String
 import Json.Decode exposing (..)
 
 
-getWitharesponseheader : Http.Request (String)
+getWitharesponseheader : Http.Request (Http.Response (String))
 getWitharesponseheader =
     Http.request
         { method =
@@ -19,7 +20,11 @@ getWitharesponseheader =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson string
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString string response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/postBooksSource.elm
+++ b/test/elm-sources/postBooksSource.elm
@@ -1,9 +1,10 @@
 module PostBooksSource exposing (..)
 
+import String.Conversions as String
 import Http
 
 
-postBooks : Book -> Http.Request (NoContent)
+postBooks : Book -> Http.Request (Http.Response (NoContent))
 postBooks body =
     Http.request
         { method =
@@ -19,9 +20,9 @@ postBooks body =
             Http.jsonBody (encodeBook body)
         , expect =
             Http.expectStringResponse
-                (\{ body } ->
-                    if String.isEmpty body then
-                        Ok NoContent
+                (\response ->
+                    if String.isEmpty response.body then
+                        Ok { response | body = NoContent }
                     else
                         Err "Expected the response body to be empty"
                 )

--- a/test/elm-sources/postTwoSource.elm
+++ b/test/elm-sources/postTwoSource.elm
@@ -25,7 +25,7 @@ postTwo body =
                 (\response ->
                     Result.map
                         (\body -> { response | body = body })
-                        (decodeString (maybe int) response.body))
+                        (decodeString (nullable int) response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/postTwoSource.elm
+++ b/test/elm-sources/postTwoSource.elm
@@ -1,11 +1,12 @@
 module PostTwoSource exposing (..)
 
 import Http
+import String.Conversions as String
 import Json.Decode exposing (..)
 import Json.Encode
 
 
-postTwo : String -> Http.Request (Maybe (Int))
+postTwo : String -> Http.Request (Http.Response (Maybe (Int)))
 postTwo body =
     Http.request
         { method =
@@ -20,7 +21,11 @@ postTwo body =
         , body =
             Http.jsonBody (Json.Encode.string body)
         , expect =
-            Http.expectJson (maybe int)
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString (maybe int) response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/putNothingSource.elm
+++ b/test/elm-sources/putNothingSource.elm
@@ -1,9 +1,10 @@
 module PutNothingSource exposing (..)
 
+import String.Conversions as String
 import Http
 
 
-putNothing : Http.Request (())
+putNothing : Http.Request (Http.Response (()))
 putNothing =
     Http.request
         { method =
@@ -19,9 +20,9 @@ putNothing =
             Http.emptyBody
         , expect =
             Http.expectStringResponse
-                (\{ body } ->
-                    if String.isEmpty body then
-                        Ok ()
+                (\response ->
+                    if String.isEmpty response.body then
+                        Ok { response | body = () }
                     else
                         Err "Expected the response body to be empty"
                 )


### PR DESCRIPTION
Looks like tests on our master are broken.