### PR TITLE
Bump to lts-12.10

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,19 +1,19 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.0
+resolver: lts-12.10
 
 # Local packages, usually specified by relative directory name
 packages:
-- '.'
+  - "."
 
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-- location:
-    git: git@github.com:NoRedInk/elm-export
-    commit: a4307e6f641e057f247584115e1a0436d72ad924
-  extra-dep: true
+  # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+  - location:
+      git: git@github.com:NoRedInk/elm-export
+      commit: 33267094fd2ea3d13d4bc8fb2a7398e004f4280f
+    extra-dep: true
 
-# Override default flag values for local packages and extra-deps
+  # Override default flag values for local packages and extra-deps
 flags: {}
 
 # Extra package databases containing global packages


### PR DESCRIPTION
This is still not functional. Something changed with
`Servant.Foreign.listFromAPI` and now our types are being wrapped in
unnecessary Maybes.

Things just went from:

```
Arg {_argName = PathSegment {unPathSegment = "year"}, _argType = ElmPrimitive EInt}, _queryArgType = Normal}
```

To:

```
Arg {_argName = PathSegment {unPathSegment = "year"}, _argType = ElmPrimitive (EMaybe (ElmPrimitive EInt))}, _queryArgType = Normal}
```