### PR TITLE
Drop 'query_' prefix from request for QueryParams

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -348,7 +348,7 @@ mkLetParams opts request =
               argType = qarg ^. F.queryArgName . F.argType
             in
                 name <$>
-                indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (name <> "[]=") <+> "++ (val |>" <+> toStringSrc "|>" opts argType <+> "Url.percentEncode)") <$>
+                indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (elmName <> "[]=") <+> "++ (val |>" <+> toStringSrc "|>" opts argType <+> "Url.percentEncode)") <$>
                       "|> String.join" <+> dquotes "&")
       where
         name = elmQueryArg qarg


### PR DESCRIPTION
This fixes a bug where using
```haskell
 :> QueryParams "versions" Text
```

Causes the generated elm code to pass this as 'query_versions' in the request (rather than 'versions' as named in the Servant type)