### PR TITLE
Lambda enclosed in aligned parens to support Elm language server parsing

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -366,6 +366,11 @@ mkLetParams opts request =
         name = elmQueryArg qarg
         elmName= qarg ^. F.queryArgName . F.argName . to (stext . F.unPathSegment)
 
+{-| Wrap a doc in parenthesis ensuring the closing parenthesis is at the same level of indentation as the opening.
+-}
+alignedParens :: Doc -> Doc
+alignedParens doc =
+    "(" <> doc <> line <> ")"
 
 mkRequest :: Doc -> ElmOptions -> F.Req ElmDatatype -> Doc
 mkRequest httpLib opts request =
@@ -424,7 +429,7 @@ mkRequest httpLib opts request =
                 Elm.toElmTypeRefWith (elmExportOptions opts) elmTypeExpr
           in
           httpLib <> ".expectStringResponse toMsg" <$>
-          indent i (parens (backslash <> "res" <+> "->" <$>
+          indent i (alignedParens (backslash <> "res" <+> "->" <$>
               indent i "case res of" <$>
               indent i (
                 indent i "Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)" <$>
@@ -445,7 +450,7 @@ mkRequest httpLib opts request =
 
         Just elmTypeExpr ->
           httpLib <> ".expectStringResponse toMsg" <$>
-          indent i (parens (backslash <> "res" <+> "->" <$>
+          indent i (alignedParens (backslash <> "res" <+> "->" <$>
               indent i "case res of" <$>
               indent i (
                 indent i "Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)" <$>

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -39,9 +39,9 @@ type TestApi =
          :> Get '[JSON] [Book]
   :<|> "books"
          :> ReqBody '[JSON] Book
-         :> PostNoContent '[JSON] NoContent
+         :> PostNoContent -- '[JSON] NoContent
   :<|> "nothing"
-         :> GetNoContent '[JSON] NoContent
+         :> GetNoContent -- '[JSON] NoContent
   :<|> "nothing"
          :> Put '[JSON] () -- old way to specify no content
   :<|> "with-a-header"

--- a/test/elm-sources/getBooksByIdSource.elm
+++ b/test/elm-sources/getBooksByIdSource.elm
@@ -34,7 +34,8 @@ getBooksById toMsg capture_id =
                             (decodeString decodeBook body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =
@@ -69,7 +70,8 @@ getBooksByIdSimulated toMsg capture_id =
                             (decodeString decodeBook body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/getBooksByTitleSource.elm
+++ b/test/elm-sources/getBooksByTitleSource.elm
@@ -34,7 +34,8 @@ getBooksByTitle toMsg capture_title =
                             (decodeString decodeBook body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =
@@ -69,7 +70,8 @@ getBooksByTitleSimulated toMsg capture_title =
                             (decodeString decodeBook body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -56,7 +56,8 @@ getBooks toMsg query_published query_sort query_year query_filters =
                                 (decodeString (list decodeBook) body_)
                                     |> Result.mapError Json.Decode.errorToString
                                     |> Result.mapError Http.BadBody
-                                    |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                    |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                    )
             , timeout =
                 Nothing
             , tracker =
@@ -112,7 +113,8 @@ getBooksSimulated toMsg query_published query_sort query_year query_filters =
                                 (decodeString (list decodeBook) body_)
                                     |> Result.mapError Json.Decode.errorToString
                                     |> Result.mapError Http.BadBody
-                                    |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                    |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                    )
             , timeout =
                 Nothing
             , tracker =

--- a/test/elm-sources/getNothingSource.elm
+++ b/test/elm-sources/getNothingSource.elm
@@ -33,7 +33,8 @@ getNothing toMsg =
                                 Ok (NoContent)
                             else
                                 Err (Just (metadata, body_), Http.BadBody <| "Expected the response body to be empty, but it was '" ++ body_ ++ "'.")
-                            )
+                            
+                )
         , timeout =
             Nothing
         , tracker =
@@ -68,7 +69,8 @@ getNothingSimulated toMsg =
                                 Ok (NoContent)
                             else
                                 Err (Just (metadata, body_), Http.BadBody <| "Expected the response body to be empty, but it was '" ++ body_ ++ "'.")
-                            )
+                            
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/getOneSource.elm
+++ b/test/elm-sources/getOneSource.elm
@@ -33,7 +33,8 @@ getOne toMsg =
                             (decodeString int body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =
@@ -67,7 +68,8 @@ getOneSimulated toMsg =
                             (decodeString int body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/getOneWithDynamicUrlSource.elm
+++ b/test/elm-sources/getOneWithDynamicUrlSource.elm
@@ -33,7 +33,8 @@ getOne toMsg urlBase =
                             (decodeString int body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =
@@ -67,7 +68,8 @@ getOneSimulated toMsg urlBase =
                             (decodeString int body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -35,7 +35,8 @@ getWithaheader toMsg header_myStringHeader header_MyIntHeader =
                             (decodeString string body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =
@@ -71,7 +72,8 @@ getWithaheaderSimulated toMsg header_myStringHeader header_MyIntHeader =
                             (decodeString string body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/getWitharesponseheaderSource.elm
+++ b/test/elm-sources/getWitharesponseheaderSource.elm
@@ -33,7 +33,8 @@ getWitharesponseheader toMsg =
                             (decodeString string body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =
@@ -67,7 +68,8 @@ getWitharesponseheaderSimulated toMsg =
                             (decodeString string body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/postBooksSource.elm
+++ b/test/elm-sources/postBooksSource.elm
@@ -33,7 +33,8 @@ postBooks toMsg body =
                                 Ok (NoContent)
                             else
                                 Err (Just (metadata, body_), Http.BadBody <| "Expected the response body to be empty, but it was '" ++ body_ ++ "'.")
-                            )
+                            
+                )
         , timeout =
             Nothing
         , tracker =
@@ -68,7 +69,8 @@ postBooksSimulated toMsg body =
                                 Ok (NoContent)
                             else
                                 Err (Just (metadata, body_), Http.BadBody <| "Expected the response body to be empty, but it was '" ++ body_ ++ "'.")
-                            )
+                            
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/postTwoSource.elm
+++ b/test/elm-sources/postTwoSource.elm
@@ -34,7 +34,8 @@ postTwo toMsg body =
                             (decodeString (nullable int) body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =
@@ -68,7 +69,8 @@ postTwoSimulated toMsg body =
                             (decodeString (nullable int) body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
-                                |> Result.mapError (Tuple.pair (Just (metadata, body_))))
+                                |> Result.mapError (Tuple.pair (Just (metadata, body_)))
+                )
         , timeout =
             Nothing
         , tracker =

--- a/test/elm-sources/putNothingSource.elm
+++ b/test/elm-sources/putNothingSource.elm
@@ -33,7 +33,8 @@ putNothing toMsg =
                                 Ok (())
                             else
                                 Err (Just (metadata, body_), Http.BadBody <| "Expected the response body to be empty, but it was '" ++ body_ ++ "'.")
-                            )
+                            
+                )
         , timeout =
             Nothing
         , tracker =
@@ -68,7 +69,8 @@ putNothingSimulated toMsg =
                                 Ok (())
                             else
                                 Err (Just (metadata, body_), Http.BadBody <| "Expected the response body to be empty, but it was '" ++ body_ ++ "'.")
-                            )
+                            
+                )
         , timeout =
             Nothing
         , tracker =


### PR DESCRIPTION
As part of [this item](https://linear.app/noredink/issue/KRA-217/rostering-standards-endpoints-should-check-authorization-headers) I have need to generate some Elm API endpoints from Rostering.

The current generation breaks the parsing of the Elm Language server that is used by VS Code (at least, probably other setups as well) and this leads to a really bad developer experience. Not only are errors reported in the generated files but also any Elm files that depend on those generated artifacts (ex. Curriculum). 

This PR attempts to fix it by simply emitting lambdas wrapped in column aligned parenthesis.

It is a really small change. I updated 1 code file and 11 expectations. 

## Prior to the Fix
![image](https://user-images.githubusercontent.com/1877273/161085210-40046fc1-fb89-4899-86d6-f88a314efbd9.png)

## After the Fix
![image](https://user-images.githubusercontent.com/1877273/161085644-c5616b18-3366-4f9c-982f-bff09dc5b3f2.png)


