### PR TITLE
Generate additional Elm endpoints that use `Task`

### DIFF
--- a/test/Common.hs
+++ b/test/Common.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE DataKinds     #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Common where
 
 import           Data.Aeson   (ToJSON)
 import           Data.Proxy   (Proxy (Proxy))
 import           Data.Text    (Text)
-import           Elm          (ElmType)
+import           Elm          (ElmType(..), ElmDatatype(..), ElmPrimitive(..))
 import           GHC.Generics (Generic)
 import           Servant.API  ((:<|>), (:>), Capture, Get, GetNoContent, Header,
                                Headers, JSON, NoContent, Post, PostNoContent,
@@ -28,6 +29,9 @@ newtype Id = Id Int
   deriving (Generic)
 
 instance ElmType Id
+
+instance ElmType (Headers a String) where
+  toElmType _ = ElmPrimitive EString
 
 type TestApi =
        "one"

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE DataKinds     #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE FlexibleInstances #-}
 module Common where
 
 import           Data.Aeson   (ToJSON)
 import           Data.Proxy   (Proxy (Proxy))
 import           Data.Text    (Text)
-import           Elm          (ElmType(..), ElmDatatype(..), ElmPrimitive(..))
+import           Elm          (ElmType)
 import           GHC.Generics (Generic)
 import           Servant.API  ((:<|>), (:>), Capture, Get, GetNoContent, Header,
                                Headers, JSON, NoContent, Post, PostNoContent,
@@ -29,9 +28,6 @@ newtype Id = Id Int
   deriving (Generic)
 
 instance ElmType Id
-
-instance ElmType (Headers a String) where
-  toElmType _ = ElmPrimitive EString
 
 type TestApi =
        "one"

--- a/test/elm-sources/getBooksByAuthor.elm
+++ b/test/elm-sources/getBooksByAuthor.elm
@@ -10,7 +10,13 @@ import Json.Decode exposing (..)
 
 getBooksbyauthorByAuthor : (Result (Maybe (Http.Metadata, String), Http.Error) (Book) -> msg) -> Id -> Author -> Cmd msg
 getBooksbyauthorByAuthor toMsg header_Id capture_author =
-    Http.request
+    getBooksbyauthorByAuthorTask header_Id capture_author |>
+        Task.attempt toMsg
+
+
+getBooksbyauthorByAuthorTask : Id -> Author -> Task (Maybe (Http.Metadata, String), Http.Error) (Book)
+getBooksbyauthorByAuthorTask header_Id capture_author =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -24,8 +30,8 @@ getBooksbyauthorByAuthor toMsg header_Id capture_author =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -40,14 +46,18 @@ getBooksbyauthorByAuthor toMsg header_Id capture_author =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getBooksbyauthorByAuthorSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (Book) -> msg) -> Id -> Author -> ProgramTest.SimulatedEffect msg
 getBooksbyauthorByAuthorSimulated toMsg header_Id capture_author =
-    SimulatedEffect.Http.request
+    getBooksbyauthorByAuthorSimulatedTask header_Id capture_author |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getBooksbyauthorByAuthorSimulatedTask : Id -> Author -> ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (Book)
+getBooksbyauthorByAuthorSimulatedTask header_Id capture_author =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -61,8 +71,8 @@ getBooksbyauthorByAuthorSimulated toMsg header_Id capture_author =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -76,7 +86,5 @@ getBooksbyauthorByAuthorSimulated toMsg header_Id capture_author =
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/getBooksByIdSource.elm
+++ b/test/elm-sources/getBooksByIdSource.elm
@@ -9,7 +9,13 @@ import Url
 
 getBooksById : (Result (Maybe (Http.Metadata, String), Http.Error) (Book) -> msg) -> Int -> Cmd msg
 getBooksById toMsg capture_id =
-    Http.request
+    getBooksByIdTask capture_id |>
+        Task.attempt toMsg
+
+
+getBooksByIdTask : Int -> Task (Maybe (Http.Metadata, String), Http.Error) (Book)
+getBooksByIdTask capture_id =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -22,8 +28,8 @@ getBooksById toMsg capture_id =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -38,14 +44,18 @@ getBooksById toMsg capture_id =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getBooksByIdSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (Book) -> msg) -> Int -> ProgramTest.SimulatedEffect msg
 getBooksByIdSimulated toMsg capture_id =
-    SimulatedEffect.Http.request
+    getBooksByIdSimulatedTask capture_id |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getBooksByIdSimulatedTask : Int -> ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (Book)
+getBooksByIdSimulatedTask capture_id =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -58,8 +68,8 @@ getBooksByIdSimulated toMsg capture_id =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -73,7 +83,5 @@ getBooksByIdSimulated toMsg capture_id =
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/getBooksByTitleSource.elm
+++ b/test/elm-sources/getBooksByTitleSource.elm
@@ -9,7 +9,13 @@ import Url
 
 getBooksByTitle : (Result (Maybe (Http.Metadata, String), Http.Error) (Book) -> msg) -> String -> Cmd msg
 getBooksByTitle toMsg capture_title =
-    Http.request
+    getBooksByTitleTask capture_title |>
+        Task.attempt toMsg
+
+
+getBooksByTitleTask : String -> Task (Maybe (Http.Metadata, String), Http.Error) (Book)
+getBooksByTitleTask capture_title =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -22,8 +28,8 @@ getBooksByTitle toMsg capture_title =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -38,14 +44,18 @@ getBooksByTitle toMsg capture_title =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getBooksByTitleSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (Book) -> msg) -> String -> ProgramTest.SimulatedEffect msg
 getBooksByTitleSimulated toMsg capture_title =
-    SimulatedEffect.Http.request
+    getBooksByTitleSimulatedTask capture_title |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getBooksByTitleSimulatedTask : String -> ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (Book)
+getBooksByTitleSimulatedTask capture_title =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -58,8 +68,8 @@ getBooksByTitleSimulated toMsg capture_title =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -73,7 +83,5 @@ getBooksByTitleSimulated toMsg capture_title =
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/getNothingSource.elm
+++ b/test/elm-sources/getNothingSource.elm
@@ -8,7 +8,13 @@ import ProgramTest
 
 getNothing : (Result (Maybe (Http.Metadata, String), Http.Error) (NoContent) -> msg) -> Cmd msg
 getNothing toMsg =
-    Http.request
+    getNothingTask |>
+        Task.attempt toMsg
+
+
+getNothingTask : Task (Maybe (Http.Metadata, String), Http.Error) (NoContent)
+getNothingTask =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -20,8 +26,8 @@ getNothing toMsg =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -37,14 +43,18 @@ getNothing toMsg =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getNothingSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (NoContent) -> msg) -> ProgramTest.SimulatedEffect msg
 getNothingSimulated toMsg =
-    SimulatedEffect.Http.request
+    getNothingSimulatedTask |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getNothingSimulatedTask : ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (NoContent)
+getNothingSimulatedTask =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -56,8 +66,8 @@ getNothingSimulated toMsg =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -72,7 +82,5 @@ getNothingSimulated toMsg =
                             
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/getOneSource.elm
+++ b/test/elm-sources/getOneSource.elm
@@ -9,7 +9,13 @@ import Json.Decode exposing (..)
 
 getOne : (Result (Maybe (Http.Metadata, String), Http.Error) (Int) -> msg) -> Cmd msg
 getOne toMsg =
-    Http.request
+    getOneTask |>
+        Task.attempt toMsg
+
+
+getOneTask : Task (Maybe (Http.Metadata, String), Http.Error) (Int)
+getOneTask =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -21,8 +27,8 @@ getOne toMsg =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -37,14 +43,18 @@ getOne toMsg =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getOneSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (Int) -> msg) -> ProgramTest.SimulatedEffect msg
 getOneSimulated toMsg =
-    SimulatedEffect.Http.request
+    getOneSimulatedTask |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getOneSimulatedTask : ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (Int)
+getOneSimulatedTask =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -56,8 +66,8 @@ getOneSimulated toMsg =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -71,7 +81,5 @@ getOneSimulated toMsg =
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/getOneWithDynamicUrlSource.elm
+++ b/test/elm-sources/getOneWithDynamicUrlSource.elm
@@ -9,7 +9,13 @@ import Json.Decode exposing (..)
 
 getOne : (Result (Maybe (Http.Metadata, String), Http.Error) (Int) -> msg) -> String -> Cmd msg
 getOne toMsg urlBase =
-    Http.request
+    getOneTask urlBase |>
+        Task.attempt toMsg
+
+
+getOneTask : String -> Task (Maybe (Http.Metadata, String), Http.Error) (Int)
+getOneTask urlBase =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -21,8 +27,8 @@ getOne toMsg urlBase =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -37,14 +43,18 @@ getOne toMsg urlBase =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getOneSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (Int) -> msg) -> String -> ProgramTest.SimulatedEffect msg
 getOneSimulated toMsg urlBase =
-    SimulatedEffect.Http.request
+    getOneSimulatedTask urlBase |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getOneSimulatedTask : String -> ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (Int)
+getOneSimulatedTask urlBase =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -56,8 +66,8 @@ getOneSimulated toMsg urlBase =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -71,7 +81,5 @@ getOneSimulated toMsg urlBase =
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -9,7 +9,13 @@ import Json.Decode exposing (..)
 
 getWithaheader : (Result (Maybe (Http.Metadata, String), Http.Error) (String) -> msg) -> String -> Int -> Cmd msg
 getWithaheader toMsg header_myStringHeader header_MyIntHeader =
-    Http.request
+    getWithaheaderTask header_myStringHeader header_MyIntHeader |>
+        Task.attempt toMsg
+
+
+getWithaheaderTask : String -> Int -> Task (Maybe (Http.Metadata, String), Http.Error) (String)
+getWithaheaderTask header_myStringHeader header_MyIntHeader =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -23,8 +29,8 @@ getWithaheader toMsg header_myStringHeader header_MyIntHeader =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -39,14 +45,18 @@ getWithaheader toMsg header_myStringHeader header_MyIntHeader =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getWithaheaderSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (String) -> msg) -> String -> Int -> ProgramTest.SimulatedEffect msg
 getWithaheaderSimulated toMsg header_myStringHeader header_MyIntHeader =
-    SimulatedEffect.Http.request
+    getWithaheaderSimulatedTask header_myStringHeader header_MyIntHeader |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getWithaheaderSimulatedTask : String -> Int -> ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (String)
+getWithaheaderSimulatedTask header_myStringHeader header_MyIntHeader =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -60,8 +70,8 @@ getWithaheaderSimulated toMsg header_myStringHeader header_MyIntHeader =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -75,7 +85,5 @@ getWithaheaderSimulated toMsg header_myStringHeader header_MyIntHeader =
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/getWitharesponseheaderSource.elm
+++ b/test/elm-sources/getWitharesponseheaderSource.elm
@@ -9,7 +9,13 @@ import Json.Decode exposing (..)
 
 getWitharesponseheader : (Result (Maybe (Http.Metadata, String), Http.Error) (String) -> msg) -> Cmd msg
 getWitharesponseheader toMsg =
-    Http.request
+    getWitharesponseheaderTask |>
+        Task.attempt toMsg
+
+
+getWitharesponseheaderTask : Task (Maybe (Http.Metadata, String), Http.Error) (String)
+getWitharesponseheaderTask =
+    Http.task
         { method =
             "GET"
         , headers =
@@ -21,8 +27,8 @@ getWitharesponseheader toMsg =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -37,14 +43,18 @@ getWitharesponseheader toMsg =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 getWitharesponseheaderSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (String) -> msg) -> ProgramTest.SimulatedEffect msg
 getWitharesponseheaderSimulated toMsg =
-    SimulatedEffect.Http.request
+    getWitharesponseheaderSimulatedTask |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+getWitharesponseheaderSimulatedTask : ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (String)
+getWitharesponseheaderSimulatedTask =
+    SimulatedEffect.Http.task
         { method =
             "GET"
         , headers =
@@ -56,8 +66,8 @@ getWitharesponseheaderSimulated toMsg =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -71,7 +81,5 @@ getWitharesponseheaderSimulated toMsg =
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/postTwoSource.elm
+++ b/test/elm-sources/postTwoSource.elm
@@ -37,7 +37,7 @@ postTwoTask body =
                         Http.NetworkError_ -> Err (Nothing, Http.NetworkError)
                         Http.BadStatus_ metadata body_ -> Err (Just (metadata, body_), Http.BadStatus metadata.statusCode)
                         Http.GoodStatus_ metadata body_ ->
-                            (decodeString (maybe int) body_)
+                            (decodeString (nullable int) body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
@@ -76,7 +76,7 @@ postTwoSimulatedTask body =
                         Http.NetworkError_ -> Err (Nothing, Http.NetworkError)
                         Http.BadStatus_ metadata body_ -> Err (Just (metadata, body_), Http.BadStatus metadata.statusCode)
                         Http.GoodStatus_ metadata body_ ->
-                            (decodeString (maybe int) body_)
+                            (decodeString (nullable int) body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))

--- a/test/elm-sources/postTwoSource.elm
+++ b/test/elm-sources/postTwoSource.elm
@@ -10,7 +10,13 @@ import Json.Encode
 
 postTwo : (Result (Maybe (Http.Metadata, String), Http.Error) (Maybe (Int)) -> msg) -> String -> Cmd msg
 postTwo toMsg body =
-    Http.request
+    postTwoTask body |>
+        Task.attempt toMsg
+
+
+postTwoTask : String -> Task (Maybe (Http.Metadata, String), Http.Error) (Maybe (Int))
+postTwoTask body =
+    Http.task
         { method =
             "POST"
         , headers =
@@ -22,8 +28,8 @@ postTwo toMsg body =
                 ]
         , body =
             Http.jsonBody (Json.Encode.string body)
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -31,21 +37,25 @@ postTwo toMsg body =
                         Http.NetworkError_ -> Err (Nothing, Http.NetworkError)
                         Http.BadStatus_ metadata body_ -> Err (Just (metadata, body_), Http.BadStatus metadata.statusCode)
                         Http.GoodStatus_ metadata body_ ->
-                            (decodeString (nullable int) body_)
+                            (decodeString (maybe int) body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 postTwoSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (Maybe (Int)) -> msg) -> String -> ProgramTest.SimulatedEffect msg
 postTwoSimulated toMsg body =
-    SimulatedEffect.Http.request
+    postTwoSimulatedTask body |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+postTwoSimulatedTask : String -> ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (Maybe (Int))
+postTwoSimulatedTask body =
+    SimulatedEffect.Http.task
         { method =
             "POST"
         , headers =
@@ -57,8 +67,8 @@ postTwoSimulated toMsg body =
                 ]
         , body =
             SimulatedEffect.Http.jsonBody (Json.Encode.string body)
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -66,13 +76,11 @@ postTwoSimulated toMsg body =
                         Http.NetworkError_ -> Err (Nothing, Http.NetworkError)
                         Http.BadStatus_ metadata body_ -> Err (Just (metadata, body_), Http.BadStatus metadata.statusCode)
                         Http.GoodStatus_ metadata body_ ->
-                            (decodeString (nullable int) body_)
+                            (decodeString (maybe int) body_)
                                 |> Result.mapError Json.Decode.errorToString
                                 |> Result.mapError Http.BadBody
                                 |> Result.mapError (Tuple.pair (Just (metadata, body_)))
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }

--- a/test/elm-sources/putNothingSource.elm
+++ b/test/elm-sources/putNothingSource.elm
@@ -8,7 +8,13 @@ import ProgramTest
 
 putNothing : (Result (Maybe (Http.Metadata, String), Http.Error) (()) -> msg) -> Cmd msg
 putNothing toMsg =
-    Http.request
+    putNothingTask |>
+        Task.attempt toMsg
+
+
+putNothingTask : Task (Maybe (Http.Metadata, String), Http.Error) (())
+putNothingTask =
+    Http.task
         { method =
             "PUT"
         , headers =
@@ -20,8 +26,8 @@ putNothing toMsg =
                 ]
         , body =
             Http.emptyBody
-        , expect =
-            Http.expectStringResponse toMsg
+        , resolver =
+            Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -37,14 +43,18 @@ putNothing toMsg =
                 )
         , timeout =
             Nothing
-        , tracker =
-            Nothing
         }
 
 
 putNothingSimulated : (Result (Maybe (Http.Metadata, String), Http.Error) (()) -> msg) -> ProgramTest.SimulatedEffect msg
 putNothingSimulated toMsg =
-    SimulatedEffect.Http.request
+    putNothingSimulatedTask |>
+        SimulatedEffect.Task.attempt toMsg
+
+
+putNothingSimulatedTask : ProgramTest.SimulatedTask (Maybe (Http.Metadata, String), Http.Error) (())
+putNothingSimulatedTask =
+    SimulatedEffect.Http.task
         { method =
             "PUT"
         , headers =
@@ -56,8 +66,8 @@ putNothingSimulated toMsg =
                 ]
         , body =
             SimulatedEffect.Http.emptyBody
-        , expect =
-            SimulatedEffect.Http.expectStringResponse toMsg
+        , resolver =
+            SimulatedEffect.Http.stringResolver
                 (\res ->
                     case res of
                         Http.BadUrl_ url -> Err (Nothing, Http.BadUrl url)
@@ -72,7 +82,5 @@ putNothingSimulated toMsg =
                             
                 )
         , timeout =
-            Nothing
-        , tracker =
             Nothing
         }


### PR DESCRIPTION
### Context

In content creation, we have many cases where we need to issue lots of requests to the backend.  This is painful using our typical generated endpoints because you need to create a `Msg` constructor for each one to manage the handoffs.

A much better solution (🎩 @brian-carroll ) is to use [`Http.task`](https://package.elm-lang.org/packages/elm/http/latest/Http#task) which returns a `Task` instead of requiring a `Result err ok -> msg` argument.  `Task`s can be chained together with `andThen` and are much more flexible in generate as you can convert a `Task` to a `Cmd Msg`, but not vice versa. 

### Solution

This library generates an extra set of endpoints that return `Task`.  In fact, we redefine the `Cmd msg` endpoints to call the new `Task` endpoints.  The original endpoints maintain the same name / argument order to make upgrading the monorepo easier. 

### Reviewing

You can see what these changes look like in the diffs of the golden files of this PR. 

I also have a PR up in the monolith (https://github.com/NoRedInk/NoRedInk/pull/47150) that is targeting this branch if you would like to see the effect merging this to master would have on the monorepo. 